### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-intellij-plugin.yml
+++ b/.github/workflows/release-intellij-plugin.yml
@@ -2,6 +2,9 @@ name: Build and Release IntelliJ Plugin
 
 concurrency: build
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/setms/sew/security/code-scanning/1](https://github.com/setms/sew/security/code-scanning/1)

To fix the issue, we will introduce a `permissions` block at the workflow root level (applies to all jobs). The `contents: read` permission will allow the workflow to read the repository's contents, which is necessary for the `checkout` action. Additionally, we will add `contents: write` for the `action-gh-release` step to enable creating a release. These explicit permissions will minimize risks by restricting the workflow to only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
